### PR TITLE
Fix method args for Ruby 3

### DIFF
--- a/lib/apivore/validator.rb
+++ b/lib/apivore/validator.rb
@@ -19,13 +19,12 @@ module Apivore
       pre_checks(swagger_checker)
 
       unless has_errors?
+        args = RailsShim.action_dispatch_request_args(full_path(swagger_checker), params: params['_data'] || {}, headers: params['_headers'] || {})
+
         send(
           method,
-          *RailsShim.action_dispatch_request_args(
-            full_path(swagger_checker),
-            params: params['_data'] || {},
-            headers: params['_headers'] || {}
-          )
+          args[0],
+          **args[1]
         )
         swagger_checker.response = response
         post_checks(swagger_checker)


### PR DESCRIPTION
The hash arguments need to be explicitly splatted.

https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments